### PR TITLE
add .dir-locals to set indentation width of 3 spaces

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,1 @@
+((c++-mode (c-basic-offset . 3)))


### PR DESCRIPTION
Seems like default indentation width of this project is 3 space.