### PR TITLE
Fix Makefile 

### DIFF
--- a/Makefile.cuda
+++ b/Makefile.cuda
@@ -13,7 +13,7 @@ else ifeq ($(findstring surface,$(HOSTNAME)),surface)
    HOSTCOMP = /usr/local/tools/ic-16.0.258/bin/icpc
    MPIPATH  = /usr/local/tools/mvapich2-intel-2.2
    gpuarch := sm_35
-   EXTRA_LINK_FLAGS = -lmpich -lmpl -lpmi
+   EXTRA_LINK_FLAGS = -lmpich -lmpl -lpmi -llapack
    MPIINC = $(MPIPATH)/include
    debugdir := debug_cuda_surface
    optdir   := optimize_cuda_surface
@@ -22,10 +22,10 @@ else
    HOSTCOMP = gcc
    MPIPATH = $(dir $(shell which mpicc))../
    gpuarch := sm_60
-   EXTRA_LINK_FLAGS = -lmpi
+   EXTRA_LINK_FLAGS = -lmpi -llapack
    MPIINC = $(MPIPATH)/include
-   debugdir := debug_cuda_surface
-   optdir   := optimize_cuda_surface
+   debugdir := debug_cuda
+   optdir   := optimize_cuda
 endif
 CXX  = $(NVCC)
 MPILIB = $(MPIPATH)/lib


### PR DESCRIPTION
(1) link against lapack on other hosts than "ray" too              
(2) remove hostname "surface" suffix from debugdir/optdir for the generic case

Code uses a LAPACK routine, but in the Makefile, the -llapack option is only present for hostname "ray". Added -llapack to the other two cases (for hostname "surface", and for the generic case).

debugdir and optdir values have a hostname suffix for hosts "ray" and "surface". The generic case has a "surface" suffix too. This seems a copy/paste error; I removed the suffix for the generic case (admittedly, this is more an aesthetics issue than a bug). 