### PR TITLE
Remove BZ_DEBUG from Makefile.cuda

### DIFF
--- a/Makefile.cuda
+++ b/Makefile.cuda
@@ -32,7 +32,7 @@ MPILIB = $(MPIPATH)/lib
 
 ifeq ($(debug),yes)
    FFLAGS    = -g 
-   CXXFLAGS  = -g -x cu -I../src -c -dc -arch=$(gpuarch) -DBZ_DEBUG -DSW4_CROUTINES -DSW4_CUDA -ccbin $(HOSTCOMP)
+   CXXFLAGS  = -g -x cu -I../src -c -dc -arch=$(gpuarch) -DSW4_CROUTINES -DSW4_CUDA -ccbin $(HOSTCOMP)
    CFLAGS    = -g 
 else
    FFLAGS   = -O3 


### PR DESCRIPTION
The flag enables VERIFY2 which in turn calls std::cout which can't be
used in device functions.