### PR TITLE
Improve non-blocking MPI for BC communication

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,14 @@ else ifeq ($(findstring ray,$(HOSTNAME)),ray)
   openmp = no
   debug = no
   computername := ray
+else ifeq ($(findstring lassen,$(HOSTNAME)),lassen)
+  FC = mpif90
+  CXX = mpicxx
+  OMPOPT = -fopenmp
+  EXTRA_LINK_FLAGS = -lgfortran -lblas -llapack
+  openmp = yes
+  debug = no
+  computername := lassen
 else
   FC  = mpif90
   CXX = mpic++

--- a/Makefile.cuda
+++ b/Makefile.cuda
@@ -17,6 +17,16 @@ else ifeq ($(findstring surface,$(HOSTNAME)),surface)
    MPIINC = $(MPIPATH)/include
    debugdir := debug_cuda_surface
    optdir   := optimize_cuda_surface
+else ifeq ($(findstring lassen,$(HOSTNAME)),lassen)
+   NVCC = nvcc
+   HOSTCOMP = xlc++
+   FC = xlf90
+   MPIPATH = $(MPI_ROOT)
+   gpuarch := sm_70
+   EXTRA_LINK_FLAGS = -lmpi_ibm -L$(LAPACK_DIR) -llapack -lblas
+   MPIINC = $(MPIPATH)/include
+   debugdir := debug_cuda_lassen
+   optdir   := optimize_cuda_lassen
 else
    NVCC = nvcc
    HOSTCOMP = gcc
@@ -31,17 +41,17 @@ CXX  = $(NVCC)
 MPILIB = $(MPIPATH)/lib
 
 ifeq ($(debug),yes)
-   FFLAGS    = -g 
+   FFLAGS    = -g
    CXXFLAGS  = -g -x cu -I../src -c -dc -arch=$(gpuarch) -DSW4_CROUTINES -DSW4_CUDA -ccbin $(HOSTCOMP)
-   CFLAGS    = -g 
+   CFLAGS    = -g
 else
-   FFLAGS   = -O3 
+   FFLAGS   = -O3
    CXXFLAGS = -O3 -x cu -I../src -c -dc -arch=$(gpuarch) -DSW4_CROUTINES -DSW4_CUDA -ccbin $(HOSTCOMP) -Xptxas -v
-   CFLAGS   = -O 
+   CFLAGS   = -O
 endif
 ifdef MPIINC
   CXXFLAGS += -I$(MPIINC)
-endif	   
+endif
 
 #FFLAGS   += -Mcuda
 
@@ -63,7 +73,7 @@ endif
 ifeq ($(single),yes)
    debugdir := $(debugdir)_sp
    optdir := $(optdir)_sp
-   CXXFLAGS += -I../src/float   
+   CXXFLAGS += -I../src/float
 else
    CXXFLAGS += -I../src/double
 endif
@@ -90,9 +100,9 @@ OBJ  = main.o EW.o Source.o rhs4sg.o rhs4sg_rev.o SuperGrid.o GridPointSource.o 
 
 FOBJ = $(addprefix $(builddir)/,$(OBJ))
 
-sw4lite: $(FOBJ) 
+sw4lite: $(FOBJ)
 	@echo "********* User configuration variables **************"
-	@echo "debug=" $(debug) " proj=" $(proj) " etree=" $(etree) " SW4ROOT"= $(SW4ROOT) 
+	@echo "debug=" $(debug) " proj=" $(proj) " etree=" $(etree) " SW4ROOT"= $(SW4ROOT)
 	@echo "CXX=" $(CXX) "EXTRA_CXX_FLAGS"= $(EXTRA_CXX_FLAGS)
 	@echo "FC=" $(FC) " EXTRA_FORT_FLAGS=" $(EXTRA_FORT_FLAGS)
 	@echo "EXTRA_LINK_FLAGS"= $(EXTRA_LINK_FLAGS)
@@ -103,15 +113,15 @@ sw4lite: $(FOBJ)
 
 #$(builddir)/device-routines.o:src/device-routines.C
 #	/bin/mkdir -p $(builddir)
-#	cd $(builddir); $(NVCC) $(CXXFLAGS) -c ../$< 
+#	cd $(builddir); $(NVCC) $(CXXFLAGS) -c ../$<
 
 $(builddir)/%.o:src/%.C
 	/bin/mkdir -p $(builddir)
-	cd $(builddir); $(CXX) $(CXXFLAGS) -c ../$< 
+	cd $(builddir); $(CXX) $(CXXFLAGS) -c ../$<
 
 $(builddir)/%.o:src/%.f
 	/bin/mkdir -p $(builddir)
-	cd $(builddir); $(FC) $(FFLAGS) -c ../$< 
+	cd $(builddir); $(FC) $(FFLAGS) -c ../$<
 
 clean:
 	/bin/mkdir -p $(optdir)

--- a/Makefile.cuda
+++ b/Makefile.cuda
@@ -42,11 +42,11 @@ MPILIB = $(MPIPATH)/lib
 
 ifeq ($(debug),yes)
    FFLAGS    = -g
-   CXXFLAGS  = -g -x cu -I../src -c -dc -arch=$(gpuarch) -DSW4_CROUTINES -DSW4_CUDA -ccbin $(HOSTCOMP)
+   CXXFLAGS  = -g -x cu -I../src -c -dc -arch=$(gpuarch) -DSW4_CROUTINES -DSW4_CUDA -DSW4_NONBLOCKING -ccbin $(HOSTCOMP)
    CFLAGS    = -g
 else
    FFLAGS   = -O3
-   CXXFLAGS = -O3 -x cu -I../src -c -dc -arch=$(gpuarch) -DSW4_CROUTINES -DSW4_CUDA -ccbin $(HOSTCOMP) -Xptxas -v
+   CXXFLAGS = -O3 -x cu -I../src -c -dc -arch=$(gpuarch) -DSW4_CROUTINES -DSW4_CUDA -DSW4_NONBLOCKING -ccbin $(HOSTCOMP) -Xptxas -v
    CFLAGS   = -O
 endif
 ifdef MPIINC

--- a/src/EW.C
+++ b/src/EW.C
@@ -5067,7 +5067,7 @@ void EW::computeDT()
       float_sw4 dtCurv;
       int g = mNumberOfGrids-1;
       float_sw4  la, mu, la2mu;
-      int N=3, LDZ=1, INFO;
+      int N=3, LDZ=1, INFO=0;
       char JOBZ='N', UPLO='L';
       float_sw4 eigmax = -1;
       // always use double precision version of lapack routine, for simplicity
@@ -5102,9 +5102,9 @@ void EW::computeDT()
 	       Amat[5] = -4.*(SQR(mMetric(1,i,j,k))*mu + SQR(mMetric(1,i,j,k))*mu
 			+ SQR(mMetric(2,i,j,k))*mu + SQR(mMetric(3,i,j,k))*mu + SQR(mMetric(4,i,j,k))*la2mu)*jinv;
 // calculate eigenvalues of symmetric matrix
-//#ifndef SW4_CUDA
+#ifndef SW4_CUDA
 	       F77_FUNC(dspev,DSPEV)(JOBZ, UPLO, N, Amat, W, Z, LDZ, WORK, INFO);
-//#endif
+#endif
 	       if (INFO != 0)
 	       {
 		  printf("ERROR: computeDT: dspev returned INFO = %i for grid point (%i, %i, %i)\n", INFO, i, j, k);


### PR DESCRIPTION
Instead of using 2 `MPI_Sendrecv`s for each direction (X, Y), we can use 2 `MPI_Irecv`s and 2 `MPI_Isend`s to avoid synchronization between `MPI_Sendrecv`s.

This has been tested on LC Lassen; results for pointsource and LOH1 benchmarks have been validated. The sta10.txt outputs of the LOH1 benchmark have been compared before/after this patch, they are identical except for the timestamps.

Further optimization is possible by delaying the `MPI_Wait`s for the `MPI_Isend`s as late as possible (just before the send buffers need to be used or replaced).